### PR TITLE
feat: DevContainerをMacOS対応

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,12 @@
 		// worktrees親ディレクトリを /workspaces/my-repository-template.worktrees にマウント
 		"source=${localWorkspaceFolder}/..,target=/workspaces/my-repository-template.worktrees,type=bind,consistency=cached",
 		"source=${localWorkspaceFolder}/.devcontainer/.git-container,target=/workspace/.git,type=bind,consistency=cached",
-		"source=${localWorkspaceFolder}/.devcontainer/.gitdir-container,target=/workspaces/my-repository-template/.git/worktrees/${localWorkspaceFolderBasename}/gitdir,type=bind,consistency=cached"
+		"source=${localWorkspaceFolder}/.devcontainer/.gitdir-container,target=/workspaces/my-repository-template/.git/worktrees/${localWorkspaceFolderBasename}/gitdir,type=bind,consistency=cached",
+		// opencode設定ファイルのマウント（クロスプラットフォーム対応：WindowsはUSERPROFILE、MacはHOME）
+		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.local/share/opencode/auth.json,target=/home/node/.local/share/opencode/auth.json,type=bind,consistency=cached,readonly",
+		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.config/opencode/oh-my-opencode.json,target=/home/node/.config/opencode/oh-my-opencode.json,type=bind,consistency=cached",
+		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.config/opencode/opencode.json,target=/home/node/.config/opencode/opencode.json,type=bind,consistency=cached",
+		"source=${localEnv:HOME}${localEnv:USERPROFILE}/.config/opencode/tui.json,target=/home/node/.config/opencode/tui.json,type=bind,consistency=cached"
 	],
 	// 現在開いているワークスペースを常に /workspace にマウントして利用する
 	"workspaceFolder": "/workspace",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,11 +6,7 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
     volumes:
-      # opencode関連のファイルマウント
-      - ${HOME}/.local/share/opencode/auth.json:/home/node/.local/share/opencode/auth.json:ro
-      - ${HOME}/.config/opencode/oh-my-opencode.json:/home/node/.config/opencode/oh-my-opencode.json
-      - ${HOME}/.config/opencode/opencode.json:/home/node/.config/opencode/opencode.json
-      - ${HOME}/.config/opencode/tui.json:/home/node/.config/opencode/tui.json
+      # opencode関連のマウントは devcontainer.json で定義（クロスプラットフォーム対応）
       - bun-cache:/home/node/.bun/install/cache
       - uv-cache:/home/node/.cache/uv
       - node-modules-cache:/workspace/node_modules


### PR DESCRIPTION
Resolve #15
## 概要

DevContainer環境をWindowsに加えてMacOSでも動作するようにしました。

## 修正事項

- `devcontainer.json`にopencode設定ファイルのマウント設定を追加
  - `${localEnv:HOME}${localEnv:USERPROFILE}`を使用して、WindowsとMacOSの両方で正しく動作するように変更
  - `auth.json`、`oh-my-opencode.json`、`opencode.json`、`tui.json`の4ファイルをマウント
  
- `docker-compose.yml`からopencode関連のマウント設定を削除
  - マウント設定を`devcontainer.json`に集約することで、クロスプラットフォーム対応を実現

## 備考

- `${localEnv:HOME}${localEnv:USERPROFILE}`は、変数が存在しない環境では空文字列になるため、両方の変数を連結することで両OSに対応しています
- `docker-compose.yml`側のマウント設定は削除されていますが、ボリュームマウント（bun-cache, uv-cache等）は維持されています
