### PR TITLE
feat: Docker Composeにvenv-cacheボリュームを追加

### DIFF
--- a/.devcontainer/auto-setup.sh
+++ b/.devcontainer/auto-setup.sh
@@ -31,6 +31,8 @@ fi
 # uv sync
 echo "→ Setting up Python environment (uv sync)..."
 cd /workspace
+# Fix ownership of .venv volume (created as root by Docker)
+sudo chown -R node:node /workspace/.venv 2>/dev/null || true
 uv sync
 echo "✓ uv sync completed"
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - bun-cache:/home/node/.bun/install/cache
       - uv-cache:/home/node/.cache/uv
       - node-modules-cache:/workspace/node_modules
+      - venv-cache:/workspace/.venv
     environment:
       - UV_LINK_MODE=copy
       # メインリポジトリとworktreesのパスを環境変数として渡す
@@ -21,3 +22,4 @@ volumes:
   bun-cache:
   uv-cache:
   node-modules-cache:
+  venv-cache:


### PR DESCRIPTION
## 概要

DevContainer内で`bun install`や`uv sync`を実行した際、生成される`.venv`ディレクトリがホスト側に反映されないようにするため、Docker Composeに名前付きボリュームを追加した。

以前から`node_modules`については同様の対策が行われていたが、`.venv`については未対応だったため、このPRで対応を行った。

## 修正事項

- `docker-compose.yml`の`services.devcontainer.volumes`に`venv-cache:/workspace/.venv`を追加
- `docker-compose.yml`の`volumes`セクションに`venv-cache:`を追加

### 期待される動作

| パス | マウントタイプ | ホストとの同期 |
| --- | -------------- | -------------- |
| `/workspace/src/` など | バインドマウント | リアルタイム双方向同期 |
| `/workspace/node_modules` | 名前付きボリューム | 独立（ホスト側に反映されない） |
| `/workspace/.venv` | 名前付きボリューム | 独立（ホスト側に反映されない） |

## 備考

- Dockerのマウント適用順序により、`devcontainer.json`の`mounts`より`docker-compose.yml`の`volumes`が後で適用されるため、オーバーレイが可能
- ホスト側に既に`.venv`が存在する場合でも、コンテナ側では空のボリュームとしてマウントされる