### PR TITLE
feat: Semgrep・gitleaks・zizmor によるセキュリティスキャンを導入

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,7 +28,7 @@ jobs:
 
   semgrep:
     name: semgrep
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     if: github.actor != 'dependabot[bot]'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -39,3 +39,20 @@ jobs:
         with:
           persist-credentials: false
       - run: semgrep scan --config=auto --error
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest # zizmor-action が Docker で実行されるため slim 不可
+    permissions:
+      contents: read
+      actions: read # オンライン監査でアクション参照を解決するため
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          persona: pedantic
+          annotations: true
+          advanced-security: false # findings でジョブを失敗させる（semgrep --error と同挙動）

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,28 @@
+name: Security Scan
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-slim
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  semgrep:
+    name: semgrep
+    runs-on: ubuntu-slim
+    if: github.actor != 'dependabot[bot]'
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - run: semgrep scan --config=auto --error

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -4,14 +4,23 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {} # デフォルトの広い権限を使わないよう明示的に空にする
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gitleaks:
     name: gitleaks
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
     if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
@@ -20,9 +29,13 @@ jobs:
   semgrep:
     name: semgrep
     runs-on: ubuntu-slim
+    permissions:
+      contents: read
     if: github.actor != 'dependabot[bot]'
     container:
-      image: semgrep/semgrep
+      image: semgrep/semgrep:1.165.0@sha256:f4791a54c891eabe1188248135574e6e03dfc31dfd3f3b747c7bec7079bfed1b # v1.165.0
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - run: semgrep scan --config=auto --error

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,14 @@
+title = "gitleaks config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Global allowlist"
+paths = [
+  '''.*\.lock$''',
+  '''(go|pnpm|package|yarn)-lock\.(json|yaml|toml)$''',
+  '''node_modules/.*''',
+  '''(.*/)?test(s)?/.*fixture.*''',
+  '''\.env\.example$''',
+]

--- a/.opencode/skills/fetch-github-copilot-reviews/scripts/fetch_copilot_reviews.py
+++ b/.opencode/skills/fetch-github-copilot-reviews/scripts/fetch_copilot_reviews.py
@@ -107,7 +107,8 @@ def fetch_reviews(owner: str, repo: str, pr_number: int, use_gh_cli: bool, token
 
         req = urllib.request.Request(url, headers=headers)
         try:
-            with urllib.request.urlopen(req) as response:
+            # URLは https://api.github.com/ でハードコード。owner/repo/pr_numberはパスにのみ展開されスキームは操作不可のため file:// 注入のリスクなし
+            with urllib.request.urlopen(req) as response:  # nosemgrep
                 data = json.loads(response.read().decode("utf-8"))
                 return data
         except urllib.error.HTTPError as e:
@@ -183,7 +184,8 @@ def fetch_review_comments(
 
         req = urllib.request.Request(url, headers=headers)
         try:
-            with urllib.request.urlopen(req) as response:
+            # URLは https://api.github.com/ でハードコード。owner/repo/pr_numberはパスにのみ展開されスキームは操作不可のため file:// 注入のリスクなし
+            with urllib.request.urlopen(req) as response:  # nosemgrep
                 return json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
             return []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,9 @@ repos:
     hooks:
       - id: semgrep
         args: ['--config', 'auto', '--error']
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: 9257c6050c0261b8c57e712f632dc4a8010109a9 # v1.25.2
+    hooks:
+      - id: zizmor
+        args: ['--persona', 'pedantic']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,14 @@ repos:
       - id: detect-private-key
       - id: no-commit-to-branch
         args: [--branch, main]
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: 83d9cd684c87d95d656c1458ef04895a7f1cbd8e # v8.30.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/semgrep/semgrep
+    rev: 4cc850aff696dce0f6beddd4bb72db7f4c9abbc0 # v1.165.0
+    hooks:
+      - id: semgrep
+        args: ['--config', 'auto', '--error']

--- a/README.md
+++ b/README.md
@@ -102,13 +102,15 @@ git worktree add ../my-app.worktrees/feat-login -b feat-login
 
 ## セキュリティスキャン
 
-危険なコードやシークレット漏洩が紛れ込むリスクを機械的に検出するため、[Semgrep](https://semgrep.dev/)（SAST）と[gitleaks](https://github.com/gitleaks/gitleaks)（シークレットスキャン）を導入しています。
+危険なコードやシークレット漏洩が紛れ込むリスクを機械的に検出するため、[Semgrep](https://semgrep.dev/)（SAST）、[gitleaks](https://github.com/gitleaks/gitleaks)（シークレットスキャン）、[zizmor](https://github.com/zizmorcore/zizmor)（GitHub Actions 静的解析）を導入しています。
 
 - **Semgrep**（コードの静的解析 / SAST）: `subprocess.call(cmd, shell=True)`、SQL インジェクションになりうる文字列結合などの危険な実装パターンを検出
 - **gitleaks**（シークレットスキャン）: AWS キー、Slack トークン、Stripe の secret key などのハードコードを検出
+- **zizmor**（GitHub Actions の静的解析）: `pull_request_target` による Pwn Request、キャッシュ汚染、`permissions` の過剰付与、テンプレートインジェクションといったワークフロー固有のサプライチェーンリスクを検出
 
 > [!NOTE]
 > Semgrepは`--config auto`でリポジトリの言語構成に合わせてコミュニティルールを自動選択します。gitleaksの誤検知が出た場合は `.gitleaks.toml` の `allowlist` に追記して運用してください。
+> zizmorは`--persona pedantic`で厳しめの慣習・スタイル指摘まで出力します。必要に応じて変更してください。
 
 ## 前提条件
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ git worktree add ../my-app.worktrees/feat-login -b feat-login
 
 これにより、両方のコンテナ内で `bun run dev` を実行したまま、ブラウザでそれぞれの動作を並行して確認できます。
 
+## セキュリティスキャン
+
+危険なコードやシークレット漏洩が紛れ込むリスクを機械的に検出するため、[Semgrep](https://semgrep.dev/)（SAST）と[gitleaks](https://github.com/gitleaks/gitleaks)（シークレットスキャン）を導入しています。
+
+- **Semgrep**（コードの静的解析 / SAST）: `subprocess.call(cmd, shell=True)`、SQL インジェクションになりうる文字列結合などの危険な実装パターンを検出
+- **gitleaks**（シークレットスキャン）: AWS キー、Slack トークン、Stripe の secret key などのハードコードを検出
+
+> [!NOTE]
+> Semgrepは`--config auto`でリポジトリの言語構成に合わせてコミュニティルールを自動選択します。gitleaksの誤検知が出た場合は `.gitleaks.toml` の `allowlist` に追記して運用してください。
+
 ## 前提条件
 
 ### Windowsの場合

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
+[options]
+exclude-newer = "2026-06-12T14:47:34.294612Z"
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "my-repository-template"
 version = "0.1.0"


### PR DESCRIPTION
## 概要

このテンプレートリポジトリには、危険なコードパターンやシークレットの混入を検出する仕組みがありませんでした。そのため各プロダクトへ転用する際、セキュリティリスクを持ち出すおそれがあります。

本 PR では Semgrep（SAST）・gitleaks（シークレットスキャン）・zizmor（GitHub Actions のサプライチェーン静的解析）を導入します。コミット時は pre-commit フック、PR 時は CI を使い、二段構えで検出できるようにしました。あわせて zizmor の指摘に沿ってワークフローの権限を最小化し、README にも概要を追記しています。

## 修正事項

- pre-commit フックに gitleaks / Semgrep（`--config auto --error`）/ zizmor（`--persona pedantic`）を追加しました。各ツールはコミット SHA でピン留めしています（`.pre-commit-config.yaml`）。
- `main` 向け PR で gitleaks と Semgrep を実行する CI ワークフローを新設しました（`.github/workflows/security-scan.yml`）。ワークフロー全体の `permissions` を空にし、各ジョブには `contents: read` のみ付与しています。`concurrency` で同一 PR の多重実行をキャンセルし、`dependabot[bot]` は対象外とします。
- デフォルトルールを継承しつつ lockfile や `node_modules`、テスト fixture、`.env.example` を除外する gitleaks 設定を追加しました（`.gitleaks.toml`）。
- zizmor の指摘に対応し、ワークフローの既定 `permissions` を空にするとともに、`actions/checkout` で `persist-credentials: false` を指定して OAuth トークンの永続化を防ぎます。
- `fetch_copilot_reviews.py` で Semgrep の誤検知を抑制しました。GitHub API のベース URL はハードコードです。`owner`/`repo`/`pr_number` はパスにのみ展開されるため、`file://` 注入の経路が存在しません。この根拠をコメントで明記し、`# nosemgrep` として抑制しています。
- README に「セキュリティスキャン」セクションを追記し、3 ツールの役割と運用上の注意点をまとめました。
- uv 側にも 3 日間のサプライチェーンエイジリミット（`exclude-newer-span = "P3D"`）を反映しました（`uv.lock`）。