### PR TITLE
fix: gitleaksジョブがエラーになっていたのを修正

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
+      pull-requests: read # PRのコミット一覧取得 (GET /repos/{owner}/{repo}/pulls/{n}/commits) に必要。不足だと gitleaks-action が 403 でクラッシュする
     if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
https://github.com/yuzolabs/pi-gunshi/actions/runs/28369331914/job/84042908664?pr=1 のように権限不足でエラーになる問題を修正